### PR TITLE
update Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: ruby
 rvm:
-  - 2.6.3
+  - 2.7.2
 before_install:
   - gem install bundler -v '> 2'
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  - curl https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip > fonts.zip
+  - curl https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip > fonts.zip
   - unzip -oj fonts.zip -d fonts/ && rm -rf fonts.zip
 script:
   - bundle exec rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2-alpine
 
 # Setup
 RUN set -x && apk update && apk upgrade && apk add --no-cache \
@@ -13,8 +13,8 @@ ADD ./ /usr/src/app/
 WORKDIR /usr/src/app
 
 RUN bundle install
-RUN curl https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip > fonts.zip && \
+RUN curl https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip > fonts.zip && \
   unzip -oj fonts.zip -d fonts/ && rm -rf fonts.zip
 
 EXPOSE 4567
-CMD ["bundle exec ruby app.rb", "-o", "0.0.0.0", "-p", "4567"]
+CMD ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0", "-p", "4567"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ YAMLもしくはテキストファイル形式で書かれた[スタイル](http
 * Ruby >= v2.3
 * bundler >= 2.0
 * [ImageMagick](https://imagemagick.org/index.php)
-* [IAPexフォント](https://ipafont.ipa.go.jp/node193#jp)
+* [IAPexフォント](https://moji.or.jp/ipafont/)
 
 ### MacOS
 #### 依存パケージのインストール
@@ -38,11 +38,11 @@ $ bundle install
 
 #### フォントのダウンロード、バージョンは適宜に替えていいです
 ```sh
-$ curl https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip > fonts.zip
+$ curl https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip > fonts.zip
 $ unzip -oj fonts.zip -d fonts/ && rm -rf fonts.zip
 ```
 
-上記コマンドを使わなくても、[ここ](https://ipafont.ipa.go.jp/node193#jp)よりフォントを
+上記コマンドを使わなくても、[ここ](https://moji.or.jp/ipafont/)よりフォントを
 ダウンロードして、下記の配置になるよう解凍すればいい。
 
 ```


### PR DESCRIPTION
ありがたく使わせていただきました:pray:
Dockerを利用して使うにあたり、DockerHubからのpull, ローカルでのbuildともに軽微な修正が必要だったので、PR出しておきます:pray:

- DockerHub からのpull時、下記エラーが発生したため修正
  - Dockerのバージョンによりそうですが、ダブルクォート内が1コマンド扱いにされるようになったようです。
```
$ docker run --rm jerrywdlee/yaml_2_resume:latest                                    
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "bundle exec ruby app.rb": executable file not found in $PATH: unknown. 
```

- build時、IPAフォントのリンク切れが発生していたため新しい配布サイトに切り替え
- 常にruby2系の最新イメージを利用するように (3系は依存パッケージの都合使えないようだったのでやめました)